### PR TITLE
Set minimum cmake to 3.3 to get rid of macOS RPATH issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.9)
+cmake_minimum_required (VERSION 3.3)
 
 project (jdqz)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.3)
 
 find_package(LAPACK)
 if (NOT LAPACK_FOUND)


### PR DESCRIPTION
CMake versions prior to 3.0 handle the setting of RPATH on macOS differently, as a result i-emic executables fail at runtime, unable to find the jdqz_tools library. Changing the minimum CMake version of JDQZPP solves this.